### PR TITLE
cd to path of current buffer before running tests

### DIFF
--- a/plugin/vimux-golang.vim
+++ b/plugin/vimux-golang.vim
@@ -14,8 +14,12 @@ function! GolangCurrentPackage()
   return "."
 endfunction
 
+function! GolangCwd()
+  return escape(shellescape(expand("%:p:h"), 1), '$')
+endfunction
+
 function! GolangTestCurrentPackage()
-  call VimuxRunCommand("cd " . expand("%:p:h") . " && clear && go test -v " . GolangCurrentPackage())
+  call VimuxRunCommand("cd " . GolangCwd() . " && clear && go test -v " . GolangCurrentPackage())
 endfunction
 
 function! GolangTestFocused()
@@ -27,7 +31,7 @@ function! GolangTestFocused()
     let test_name_raw = split(line, " ")[1]
     let test_name = split(test_name_raw, "(")[0]
 
-    call VimuxRunCommand("cd " . expand("%:p:h") . " && clear && go test " . GolangFocusedCommand(test_name) . " -v " . GolangCurrentPackage())
+    call VimuxRunCommand("cd " . GolandCwd() . " && clear && go test " . GolangFocusedCommand(test_name) . " -v " . GolangCurrentPackage())
   else
     echo "No test found"
   endif

--- a/plugin/vimux-golang.vim
+++ b/plugin/vimux-golang.vim
@@ -31,7 +31,7 @@ function! GolangTestFocused()
     let test_name_raw = split(line, " ")[1]
     let test_name = split(test_name_raw, "(")[0]
 
-    call VimuxRunCommand("cd " . GolandCwd() . " && clear && go test " . GolangFocusedCommand(test_name) . " -v " . GolangCurrentPackage())
+    call VimuxRunCommand("cd " . GolangCwd() . " && clear && go test " . GolangFocusedCommand(test_name) . " -v " . GolangCurrentPackage())
   else
     echo "No test found"
   endif

--- a/plugin/vimux-golang.vim
+++ b/plugin/vimux-golang.vim
@@ -15,7 +15,7 @@ function! GolangCurrentPackage()
 endfunction
 
 function! GolangTestCurrentPackage()
-  call VimuxRunCommand("clear; go test -v " . GolangCurrentPackage())
+  call VimuxRunCommand("cd " . expand("%:p:h") . " && clear && go test -v " . GolangCurrentPackage())
 endfunction
 
 function! GolangTestFocused()
@@ -27,7 +27,7 @@ function! GolangTestFocused()
     let test_name_raw = split(line, " ")[1]
     let test_name = split(test_name_raw, "(")[0]
 
-    call VimuxRunCommand("clear; go test " . GolangFocusedCommand(test_name) . " -v " . GolangCurrentPackage())
+    call VimuxRunCommand("cd " . expand("%:p:h") . " && clear && go test " . GolangFocusedCommand(test_name) . " -v " . GolangCurrentPackage())
   else
     echo "No test found"
   endif


### PR DESCRIPTION
This is a fix for issue #1

I also changed from using ; to && so that entire command line will be aborted if the cd fails.  I'm not sure if that limits the shells this will run it, but it should be fine with sh, bash and zsh at the least.

I think that the GolangCurrentPackage() function should be removed, and that tests should be run without the -v flag.  If you agree I will add those changes to this pull request.
